### PR TITLE
Removing apt-clean

### DIFF
--- a/browsers/Dockerfile
+++ b/browsers/Dockerfile
@@ -25,10 +25,6 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     google-chrome-stable
 
-# Try to shrink
-RUN apt-get clean
-RUN apt-get autoremove -y
-
 # Chrome remote debugger port
 EXPOSE 9222:9222
 # VNC

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -19,7 +19,3 @@ RUN chmod a+x /usr/local/bin/nave
 
 # Build/install NodeJS
 RUN nave usemain $NODE_VERSION
-
-# Try to shrink
-RUN apt-get clean
-RUN apt-get autoremove -y


### PR DESCRIPTION
Looks like apt-get clean and autoremove do not have any effect on the image size.  So removing.