### PR TITLE
Cleaning vartmp should help

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/browsers/Dockerfile
+++ b/browsers/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER RedJack, LLC
 
 ENV PATH /usr/local/bin:$PATH
 
-# Install Xvfb, VNC, and fonts
+# Install Xvfb, VNC, fonts, Firefox and Chrome
+RUN curl -f -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+ && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     x11vnc \
@@ -11,19 +13,11 @@ RUN apt-get update \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-    xvfb
+    xvfb \
+    firefox \
+    google-chrome-stable \
+ && rm -rf /var/lib/apt/lists/*
 
-# Install Firefox
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-    firefox
-
-# Install Chrome
-RUN curl -f -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
-    google-chrome-stable
 
 # Chrome remote debugger port
 EXPOSE 9222:9222

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
     build-essential \
     curl \
-    git
+    git \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Nave
 RUN curl -f -o /usr/local/bin/nave https://raw.githubusercontent.com/isaacs/nave/master/nave.sh


### PR DESCRIPTION
So re-arranging the order of things and combining apt-get actually has a huge effect on the image size

This commit makes browser image to be 750MB large (almost 100MB saving)

Combined with dropping ansible and pip  we are saving about 250MB  ( original browser image was 980MB )

