### PR TITLE
Adding SSH key for github.com

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -20,3 +20,7 @@ RUN chmod a+x /usr/local/bin/nave
 
 # Build/install NodeJS
 RUN nave usemain $NODE_VERSION
+
+# Add SSH host key for Github.com
+RUN mkdir -p ~/.ssh
+RUN echo github.com,192.30.252.131 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ== > ~/.ssh/known_hosts


### PR DESCRIPTION
We need to have github.com public ssh key in the image so that we can pull node modules directly from private git repos